### PR TITLE
Remove inline css from main classname located in default tsx in layout folder

### DIFF
--- a/layouts/default.tsx
+++ b/layouts/default.tsx
@@ -14,7 +14,7 @@ export default function DefaultLayout({
       <GoogleAnalytics GA_MEASUREMENT_ID="G-07XM55RLGD" />
       <Head />
       <NavbarMain />
-      <main className="container mx-auto max-w-7xl px-6 flex-grow">
+      <main>
         {children}
         <CookieBanner />
       </main>


### PR DESCRIPTION
This pull request is related to issue #48 